### PR TITLE
audio_amplifier: Add hook for amplifier calibration

### DIFF
--- a/include/hardware/audio_amplifier.h
+++ b/include/hardware/audio_amplifier.h
@@ -132,6 +132,11 @@ typedef struct amplifier_device {
      */
     int (*set_feedback)(struct amplifier_device *device,
         void *adev, uint32_t devices, bool enable);
+
+    /**
+     * Amplifier calibration
+     */
+    int (*calibrate)(void *adev);
 } amplifier_device_t;
 
 typedef struct amplifier_module {


### PR DESCRIPTION
Sometimes the amplifier will need to do calibration and fw download on the very first boot. For example, it will need to load calibration files from another partition, download calibration firmware to the amplifier and play silence sound for some seconds.

While the current interface, amp_module_open, is able to handle most of the operations mentioned above, it is not able to allow the HAL to play silence sound, because it cannot get the needed audio_device, or adev, it is not able to enable the snd device, and write silence pcm data using pcm_write interface.

This change adds an interface to allow the audio_amplifier HAL to calibrate the amplifier. It passes the required audio_device struct to audio_amplifier as a parameter, and is called after opening the audio_amplifier module.


Change-Id: I9d497fb5d9716bbcbc6ef9035205ee18da994e72

[anrui2032] Request by upstream commit: https://github.com/LineageOS/android_hardware_qcom_audio/commit/ad4e3a3c9beb57334ccc3c7bc9f99dca5f8bc24b#diff-1160b42e723bd498b7224b1ffb808f31273baacb925d45768f48ce60279d49d5R54
